### PR TITLE
fixed typo in private.go file

### DIFF
--- a/internal/command/private.go
+++ b/internal/command/private.go
@@ -75,7 +75,7 @@ func (k *cmd) runGITCommand(args ...string) (string, error) {
 	}
 
 	if err := execCmd.Wait(); err != nil {
-		return "", fmt.Errorf("can npt wait git command: %w", err)
+		return "", fmt.Errorf("can not wait git command: %w", err)
 	}
 
 	return strings.TrimSpace(out.String()), nil


### PR DESCRIPTION
Fixed a typo in the error message return of the runGITCommand() function in the private.go file